### PR TITLE
fix: disallow going inside section by crawlers

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - esbuild
-  - lefthook
   - sharp
   - unrs-resolver

--- a/src/app/(root)/(sidebar-main)/section/[sectionId]/page.tsx
+++ b/src/app/(root)/(sidebar-main)/section/[sectionId]/page.tsx
@@ -1,14 +1,7 @@
 import { getQuestion } from "./actions"
 import PreviousNextButtons from "./components/previous-next-buttons"
 import dynamic from "next/dynamic"
-import { Metadata } from "next"
 import { unstable_cache as cache } from "next/cache"
-
-export const metadata: Metadata = {
-  alternates: {
-    canonical: "/",
-  },
-}
 
 const AnswerCheckboxGroup = dynamic(
   () => import("./components/answer-checkbox-group"),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,13 +3,8 @@ import { Archivo, Artifika } from "next/font/google"
 import "./globals.css"
 import Providers from "@/providers/providers"
 import { Toaster } from "@/components/ui/sonner"
-import { env } from "@/env"
 
 export const metadata: Metadata = {
-  // TODO: instead of getting the base URL from vercel's env, we should use some
-  // other approved technique. See:
-  // https://github.com/vercel/next.js/discussions/57251
-  metadataBase: new URL(env.VERCEL_URL),
   title: {
     default: "Distrohop",
     template: "%s · Distrohop",

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /section/

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,15 +17,6 @@ export const env = createEnv({
       ),
       "false",
     ),
-    // TODO: see app/layout.tsx on why this should be removed
-    VERCEL_URL: v.optional(
-      v.pipe(
-        v.string(),
-        v.transform((u) => `https://${u}`),
-        v.url(),
-      ),
-      "https://distrohop.vercel.app",
-    ),
   },
 
   // client only env vars


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a robots.txt file to prevent web crawlers from indexing URLs under the /section/ path.

- **Chores**
  - Updated configuration by removing the VERCEL_URL environment variable and related metadata settings.
  - Cleaned up unused imports and metadata exports in several files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->